### PR TITLE
replace divs inside card grids with a tags

### DIFF
--- a/themes/dream/layouts/_default/summary.html
+++ b/themes/dream/layouts/_default/summary.html
@@ -3,13 +3,13 @@
 {{ else }}
 <article class="ui raised card dream-card">
 {{ end }}
-  <div class="image">
+  <a class="image" href="{{ .Permalink }}">
     {{ if isset .Params "cover" }}
       <img src="{{ .Params.cover }}" alt="{{ .Title }}" />
     {{ else }}
       <img src="/img/default{{ index (shuffle (seq 1 4)) 0 }}.jpg" alt="{{ .Title }}" />
     {{ end }}
-  </div>
+  </a>
 
   <div class="content">
     <h2 class="ui medium header">


### PR DESCRIPTION
This PR replaces the `<div class="image">` tag in the `summary.html` layout with links. It should make it easier to intuitively 'click' on a card when browsing on mobile. 

A better solution would be to turn the entire card into a link - this is probably a stopgap solution to that :smile: 

Here's how it looks from desktop:

![local-brixton-clickable-cards](https://user-images.githubusercontent.com/35241716/78332679-5e810980-7580-11ea-9874-8abe9e34255f.png)
